### PR TITLE
osx_terminal_exit_code_fix

### DIFF
--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -5,7 +5,7 @@ about-plugin 'osx-specific functions'
 if [ $(uname) = "Darwin" ]; then
   if type update_terminal_cwd > /dev/null 2>&1 ; then
     if ! [[ $PROMPT_COMMAND =~ (^|;)update_terminal_cwd($|;) ]] ; then
-      export PROMPT_COMMAND="update_terminal_cwd;$PROMPT_COMMAND"
+      export PROMPT_COMMAND="$PROMPT_COMMAND;update_terminal_cwd"
     fi
   fi
 fi


### PR DESCRIPTION
The update_terminal_cmd is interfering with the $? variable. Somehow it
is always 0.

```
caesium@Mac:~/Documents/projects/git/bash-it 0 >export
PROMPT_COMMAND="update_terminal_cwd;set_prompt"
caesium@Mac:~/Documents/projects/git/bash-it 0 >false
caesium@Mac:~/Documents/projects/git/bash-it 0 >true
caesium@Mac:~/Documents/projects/git/bash-it 0 >export
PROMPT_COMMAND="set_prompt;update_terminal_cwd"
caesium@Mac:~/Documents/projects/git/bash-it 0 >false
caesium@Mac:~/Documents/projects/git/bash-it 1 >true
caesium@Mac:~/Documents/projects/git/bash-it 0 >
```

After the fix it is working properly.
